### PR TITLE
Do not overwrite OPENMS_DATA_PATH in PyOpenMS if it is already set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,4 +98,4 @@ the authors tag in the respective file header.
  - Witold Wolski
  - Xiao Liang
  - Justin Sing
- 
+ - Radu Suciu

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ General:
 - OpenMS now expects a compiler that supports C17
 - Config storage path on linux changed to ~/.config/
 - Some documentation improvements to pyOpenMS https://pyopenms.readthedocs.io/en/latest/
+- PyOpenMS checks if `OPENMS_DATA_PATH` environment variable is set, before setting to default value
 
 Adapters/Third-party support:
 - Added support for SIRIUS 4.9.0

--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -28,7 +28,9 @@ from .version import version as __version__
 
 import os
 here = os.path.abspath(os.path.dirname(__file__))
-os.environ["OPENMS_DATA_PATH"] = os.path.join(here, "share/OpenMS")
+
+if not os.environ.get("OPENMS_DATA_PATH"):
+    os.environ["OPENMS_DATA_PATH"] = os.path.join(here, "share/OpenMS")
 
 import sys
 if sys.platform.startswith("linux"):


### PR DESCRIPTION
# Description

I've got a lot of customizations (mostly to `unimod.xml` ) that I've set in a new directory that is references by `OPENMS_DATA_PATH` but pyopenms clobbers that on initialization. This simple modification should prevent it from doing so, if there is a path already set.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).